### PR TITLE
Send a final reset to devices which enter DFU_STATE_dfuMANIFEST_WAIT_RST

### DIFF
--- a/src/dfu_load.c
+++ b/src/dfu_load.c
@@ -199,6 +199,16 @@ get_status:
 		milli_sleep(1000);
 		goto get_status;
 		break;
+	case DFU_STATE_dfuMANIFEST_WAIT_RST:
+		if (dfu_detach(dif->dev_handle, dif->interface, 1000) < 0) {
+			fprintf(stderr, "can't detach\n");
+		}
+		printf("Resetting USB to switch back to runtime mode\n");
+		ret = libusb_reset_device(dif->dev_handle);
+		if (ret < 0 && ret != LIBUSB_ERROR_NOT_FOUND) {
+			fprintf(stderr, "error resetting after download\n");
+		}
+		break;
 	case DFU_STATE_dfuIDLE:
 		break;
 	}


### PR DESCRIPTION
This allows the device to retun to runtime mode. It has been tested with STM32duino bootloader.